### PR TITLE
Fire waiting_for_ssh event on boot of new instance

### DIFF
--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -523,6 +523,15 @@ def create(vm_):
     # If a password wasn't supplied in the profile or provider config, set it now.
     vm_['password'] = get_password(vm_)
 
+    # Send event that the instance has booted.
+    salt.utils.cloud.fire_event(
+        'event',
+        'waiting for ssh',
+        'salt/cloud/{0}/waiting_for_ssh'.format(name),
+        {'ip_address': vm_['ssh_host']},
+        transport=__opts__['transport']
+    )
+
     # Bootstrap!
     ret = __utils__['cloud.bootstrap'](vm_, __opts__)
 


### PR DESCRIPTION
### What does this PR do?
Make the IP that the new instance will use to communicate with the master available before the bootstrap script is run.  We use this to open the firewall on the master.

### Tests written?
No, but in production use.